### PR TITLE
Was logged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ pom.xml.asc
 .DS_Store
 /vendor
 .eastwood
+/.idea

--- a/test/src/cartus/test.clj
+++ b/test/src/cartus/test.clj
@@ -36,43 +36,46 @@
   [test-logger]
   @(:events test-logger))
 
-(defn was-logged?
-  "Returns true if the given event was logged"
-  [logger modifiers & log-specs]
-  (let [resolved-log-specs
-        (if (map? modifiers)
-          (vec (cons modifiers log-specs))
-          log-specs)
+(defmacro create-outcome [logger modifiers log-specs]
+  `(let [resolved-log-specs#
+         (if (map? ~modifiers)
+           (vec (cons ~modifiers ~log-specs))
+           ~log-specs)
 
-        resolved-modifiers
-        (if (set? modifiers)
-          modifiers
-          #{})]
-    (let [overrides {}
-          overrides (if (:strict-contents resolved-modifiers)
-                       (merge overrides {map? mc-matchers/equals})
-                       overrides)
+         resolved-modifiers#
+         (if (set? ~modifiers)
+           ~modifiers
+           #{})
+         overrides# {}
+         overrides# (if (:strict-contents resolved-modifiers#)
+                      (merge overrides# {map? mc-matchers/equals})
+                      overrides#)
 
-          matcher (cond
-                     (sets/subset?
-                       #{:only :in-any-order} resolved-modifiers)
-                     (mc-matchers/in-any-order resolved-log-specs)
+         matcher# (cond
+                    (sets/subset?
+                      #{:only :in-any-order} resolved-modifiers#)
+                    (mc-matchers/in-any-order resolved-log-specs#)
 
-                     (:only resolved-modifiers)
-                     (mc-matchers/equals resolved-log-specs)
+                    (:only resolved-modifiers#)
+                    (mc-matchers/equals resolved-log-specs#)
 
-                     (:in-any-order resolved-modifiers)
-                     (mc-matchers/embeds resolved-log-specs)
+                    (:in-any-order resolved-modifiers#)
+                    (mc-matchers/embeds resolved-log-specs#)
 
-                     :else
-                     (cartus-matchers/subsequences resolved-log-specs))
-          matcher (if (not-empty overrides)
-                     (mc-matchers/match-with overrides matcher)
-                     matcher)
+                    :else
+                    (cartus-matchers/subsequences resolved-log-specs#))
+         matcher# (if (not-empty overrides#)
+                    (mc-matchers/match-with overrides# matcher#)
+                    matcher#)
 
-          result (mc-core/match matcher (events logger))
-          match? (mc-core/indicates-match? result)]
-      match?)))
+         result# (mc-core/match matcher# (events ~logger))
+         match?# (mc-core/indicates-match? result#)]
+     {:result result#
+      :match? match?#}))
+
+(defn was-logged? [logger modifiers & log-specs]
+  (let [{:keys [match?]} (create-outcome logger modifiers log-specs)]
+    match?))
 
 (declare
   ^{:doc
@@ -132,122 +135,99 @@
   logged?)
 
 (defmethod test/assert-expr 'logged? [msg form]
-  `(let [valid-modifiers?#
-         (fn [modifiers#]
-           (not
-             (or
-               (sets/subset? #{:fuzzy-contents :strict-contents} modifiers#)
-               (sets/subset? #{:only :at-least} modifiers#)
-               (sets/subset? #{:in-order :in-any-order} modifiers#))))
+    `(let [valid-modifiers?#
+           (fn [modifiers#]
+             (not
+               (or
+                 (sets/subset? #{:fuzzy-contents :strict-contents} modifiers#)
+                 (sets/subset? #{:only :at-least} modifiers#)
+                 (sets/subset? #{:in-order :in-any-order} modifiers#))))
 
-         call-expectation#
-         (symbol
-           (str
-             "logged? to be called with a test logger, an optional set "
-             "of modifiers and at least one log event spec"))
+           call-expectation#
+           (symbol
+             (str
+               "logged? to be called with a test logger, an optional set "
+               "of modifiers and at least one log event spec"))
 
-         args# (list ~@(rest form))
-         arg-count# (count args#)
+           args# (list ~@(rest form))
+           arg-count# (count args#)
 
-         [logger# modifiers# & log-specs#] args#
+           [logger# modifiers# & log-specs#] args#
 
-         resolved-log-specs#
-         (if (map? modifiers#)
-           (vec (cons modifiers# log-specs#))
-           log-specs#)
+           resolved-log-specs#
+           (if (map? modifiers#)
+             (vec (cons modifiers# log-specs#))
+             log-specs#)
 
-         resolved-modifiers#
-         (if (set? modifiers#)
-           modifiers#
-           #{})]
-     (cond
-       (= arg-count# 1)
-       (test/do-report
-         {:type     :fail
-          :message  ~msg
-          :expected call-expectation#
-          :actual   (symbol
-                      (str "only " arg-count# " argument was provided: "
-                        '~form))})
-
-       (empty? resolved-log-specs#)
-       (test/do-report
-         {:type     :fail
-          :message  ~msg
-          :expected call-expectation#
-          :actual   (symbol
-                      (str "no log specs were provided: " '~form))})
-
-       (not (or (map? modifiers#) (set? modifiers#)))
-       (test/do-report
-         {:type     :fail
-          :message  ~msg
-          :expected call-expectation#
-          :actual   (symbol
-                      (str "non-set modifiers provided: " '~form))})
-
-       (not (instance? TestLogger logger#))
-       (test/do-report
-         {:type     :fail
-          :message  ~msg
-          :expected call-expectation#
-          :actual   (symbol
-                      (str "instance other than test logger provided: "
-                        '~form))})
-
-       (not (mc-core/matcher? resolved-log-specs#))
-       (test/do-report
-         {:type     :fail
-          :message  ~msg
-          :expected call-expectation#
-          :actual   (symbol
-                      (str "non-matcher log specs provided: " '~form))})
-
-       (not (valid-modifiers?# resolved-modifiers#))
-       (test/do-report
-         {:type     :fail
-          :message  ~msg
-          :expected call-expectation#
-          :actual   (symbol
-                      (str "invalid combination of modifiers provided: "
-                        '~form))})
-
-       :else
-       (let [overrides# {}
-             overrides# (if (:strict-contents resolved-modifiers#)
-                          (merge overrides# {map? mc-matchers/equals})
-                          overrides#)
-
-             matcher# (cond
-                        (sets/subset?
-                          #{:only :in-any-order} resolved-modifiers#)
-                        (mc-matchers/in-any-order resolved-log-specs#)
-
-                        (:only resolved-modifiers#)
-                        (mc-matchers/equals resolved-log-specs#)
-
-                        (:in-any-order resolved-modifiers#)
-                        (mc-matchers/embeds resolved-log-specs#)
-
-                        :else
-                        (cartus-matchers/subsequences resolved-log-specs#))
-             matcher# (if (not-empty overrides#)
-                        (mc-matchers/match-with overrides# matcher#)
-                        matcher#)
-
-             result# (mc-core/match matcher# (events logger#))
-             match?# (mc-core/indicates-match? result#)]
+           resolved-modifiers#
+           (if (set? modifiers#)
+             modifiers#
+             #{})]
+       (cond
+         (= arg-count# 1)
          (test/do-report
-           (if match?#
-             {:type     :pass
-              :message  ~msg
-              :expected '~form
-              :actual   `('logged? ~logger# ~modifiers# ~@log-specs#)}
-             {:type     :fail
-              :message  ~msg
-              :expected '~form
-              :actual   (mc-test/tagged-for-pretty-printing
-                          (list '~'not
-                            `('logged? ~logger# ~modifiers# ~@log-specs#))
-                          result#)}))
-         match?#))))
+           {:type     :fail
+            :message  ~msg
+            :expected call-expectation#
+            :actual   (symbol
+                        (str "only " arg-count# " argument was provided: "
+                          '~form))})
+
+         (empty? resolved-log-specs#)
+         (test/do-report
+           {:type     :fail
+            :message  ~msg
+            :expected call-expectation#
+            :actual   (symbol
+                        (str "no log specs were provided: " '~form))})
+
+         (not (or (map? modifiers#) (set? modifiers#)))
+         (test/do-report
+           {:type     :fail
+            :message  ~msg
+            :expected call-expectation#
+            :actual   (symbol
+                        (str "non-set modifiers provided: " '~form))})
+
+         (not (instance? TestLogger logger#))
+         (test/do-report
+           {:type     :fail
+            :message  ~msg
+            :expected call-expectation#
+            :actual   (symbol
+                        (str "instance other than test logger provided: "
+                          '~form))})
+
+         (not (mc-core/matcher? resolved-log-specs#))
+         (test/do-report
+           {:type     :fail
+            :message  ~msg
+            :expected call-expectation#
+            :actual   (symbol
+                        (str "non-matcher log specs provided: " '~form))})
+
+         (not (valid-modifiers?# resolved-modifiers#))
+         (test/do-report
+           {:type     :fail
+            :message  ~msg
+            :expected call-expectation#
+            :actual   (symbol
+                        (str "invalid combination of modifiers provided: "
+                          '~form))})
+
+         :else
+         (let [result# (create-outcome logger# modifiers# log-specs#)]
+           (test/do-report
+             (if (:match? result#)
+               {:type     :pass
+                :message  ~msg
+                :expected '~form
+                :actual   `('logged? ~logger# ~modifiers# ~@log-specs#)}
+               {:type     :fail
+                :message  ~msg
+                :expected '~form
+                :actual   (mc-test/tagged-for-pretty-printing
+                            (list '~'not
+                              `('logged? ~logger# ~modifiers# ~@log-specs#))
+                            (:result result#))}))
+           (:match? result#)))))

--- a/test/src/cartus/test.clj
+++ b/test/src/cartus/test.clj
@@ -37,33 +37,24 @@
   @(:events test-logger))
 
 (defmacro create-outcome [logger modifiers log-specs]
-  `(let [resolved-log-specs#
-         (if (map? ~modifiers)
-           (vec (cons ~modifiers ~log-specs))
-           ~log-specs)
-
-         resolved-modifiers#
-         (if (set? ~modifiers)
-           ~modifiers
-           #{})
-         overrides# {}
-         overrides# (if (:strict-contents resolved-modifiers#)
+  `(let [overrides# {}
+         overrides# (if (:strict-contents ~modifiers)
                       (merge overrides# {map? mc-matchers/equals})
                       overrides#)
 
          matcher# (cond
                     (sets/subset?
-                      #{:only :in-any-order} resolved-modifiers#)
-                    (mc-matchers/in-any-order resolved-log-specs#)
+                      #{:only :in-any-order} ~modifiers)
+                    (mc-matchers/in-any-order ~log-specs)
 
-                    (:only resolved-modifiers#)
-                    (mc-matchers/equals resolved-log-specs#)
+                    (:only ~modifiers)
+                    (mc-matchers/equals ~log-specs)
 
-                    (:in-any-order resolved-modifiers#)
-                    (mc-matchers/embeds resolved-log-specs#)
+                    (:in-any-order ~modifiers)
+                    (mc-matchers/embeds ~log-specs)
 
                     :else
-                    (cartus-matchers/subsequences resolved-log-specs#))
+                    (cartus-matchers/subsequences ~log-specs))
          matcher# (if (not-empty overrides#)
                     (mc-matchers/match-with overrides# matcher#)
                     matcher#)
@@ -216,7 +207,8 @@
                           '~form))})
 
          :else
-         (let [result# (create-outcome logger# modifiers# log-specs#)]
+         (let [result# (create-outcome
+                         logger# resolved-modifiers# resolved-log-specs#)]
            (test/do-report
              (if (:match? result#)
                {:type     :pass

--- a/test/src/cartus/test.clj
+++ b/test/src/cartus/test.clj
@@ -36,33 +36,33 @@
   [test-logger]
   @(:events test-logger))
 
-(defmacro create-outcome [logger modifiers log-specs]
-  `(let [overrides# {}
-         overrides# (if (:strict-contents ~modifiers)
-                      (merge overrides# {map? mc-matchers/equals})
-                      overrides#)
+(defn create-outcome [logger modifiers log-specs]
+  (let [overrides {}
+        overrides (if (:strict-contents modifiers)
+                    (merge overrides {map? mc-matchers/equals})
+                    overrides)
 
-         matcher# (cond
-                    (sets/subset?
-                      #{:only :in-any-order} ~modifiers)
-                    (mc-matchers/in-any-order ~log-specs)
+        matcher (cond
+                  (sets/subset?
+                    #{:only :in-any-order} modifiers)
+                  (mc-matchers/in-any-order log-specs)
 
-                    (:only ~modifiers)
-                    (mc-matchers/equals ~log-specs)
+                  (:only modifiers)
+                  (mc-matchers/equals log-specs)
 
-                    (:in-any-order ~modifiers)
-                    (mc-matchers/embeds ~log-specs)
+                  (:in-any-order modifiers)
+                  (mc-matchers/embeds log-specs)
 
-                    :else
-                    (cartus-matchers/subsequences ~log-specs))
-         matcher# (if (not-empty overrides#)
-                    (mc-matchers/match-with overrides# matcher#)
-                    matcher#)
+                  :else
+                  (cartus-matchers/subsequences log-specs))
+        matcher (if (not-empty overrides)
+                  (mc-matchers/match-with overrides matcher)
+                  matcher)
 
-         result# (mc-core/match matcher# (events ~logger))
-         match?# (mc-core/indicates-match? result#)]
-     {:result result#
-      :match? match?#}))
+        result (mc-core/match matcher (events logger))
+        match? (mc-core/indicates-match? result)]
+    {:result result
+     :match? match?}))
 
 (defn was-logged? [logger modifiers & log-specs]
   (let [{:keys [match?]} (create-outcome logger modifiers log-specs)]

--- a/test/test/cartus/test_test.clj
+++ b/test/test/cartus/test_test.clj
@@ -59,6 +59,41 @@
                             :ns (find-ns 'cartus.test-support.definitions))}]
             (cartus-test/events logger))))))
 
+(deftest was-logged?-does-not-find-missing-match
+  (let [logger (cartus-test/logger)
+        type ::some.event
+        context {:some "context"}
+
+        _ ^{:line 1 :column 1} (cartus-core/info logger type context)
+
+        log-event {:level   :info
+                   :type    ::OTHER.event
+                   :context context
+                   :meta    {:ns     (find-ns 'cartus.test-test)
+                             :line   1
+                             :column 1}}
+
+        was-logged (cartus-test/was-logged? logger #{} log-event)]
+    (is (false? was-logged))))
+
+(deftest was-logged?-finds-match
+  (let [logger (cartus-test/logger)
+        type ::some.event
+        context {:some "context"}
+
+        _ ^{:line 1 :column 1} (cartus-core/info logger type context)
+
+        log-event {:level   :info
+                   :type    type
+                   :context context
+                   :meta    {:ns     (find-ns 'cartus.test-test)
+                             :line   1
+                             :column 1}}
+
+        was-logged (cartus-test/was-logged? logger #{} log-event)]
+    (is (true? was-logged))))
+
+
 (deftest logged?-matches-single-log-event-exactly
   (let [logger (cartus-test/logger)
         type ::some.event

--- a/test/test/cartus/test_test.clj
+++ b/test/test/cartus/test_test.clj
@@ -93,7 +93,6 @@
         was-logged (cartus-test/was-logged? logger #{} log-event)]
     (is (true? was-logged))))
 
-
 (deftest logged?-matches-single-log-event-exactly
   (let [logger (cartus-test/logger)
         type ::some.event


### PR DESCRIPTION
* Adds a "was-logged?" function which can be used to assert if something was logged outside the context of a clojure.test/is assertion.
* Extracts a "create-outcome" function to re-use code between "logged?" and "was-logged?"
* Q: Do we care about a 2 arity implementation of was-logged?